### PR TITLE
Accept context for deferred jobs

### DIFF
--- a/lib/fastdom.js
+++ b/lib/fastdom.js
@@ -197,15 +197,12 @@
    * by the number of frames
    * specified.
    *
-   * @param  {Function/Object} job
-   * @param  {Number}          frames
+   * @param  {Number}   frames
+   * @param  {Function} fn
    * @api public
    */
-  FastDom.prototype.defer = function(job, frames) {
-    // Accepts a function or an object
-    // consists of function and its context
-    var fn = job.fn || job;
-    var ctx = job.ctx || null;
+  FastDom.prototype.defer = function(frames, fn, ctx) {
+    if (frames < 0) return;
 
     (function wrapped() {
       if (frames-- === 0) {

--- a/test/test.defer.js
+++ b/test/test.defer.js
@@ -5,7 +5,7 @@ suite('defer', function(){
     var fastdom = new FastDom();
     var job = sinon.spy();
 
-    fastdom.defer(job, 4);
+    fastdom.defer(4, job);
 
     raf(function() {
       assert(!job.called);
@@ -20,5 +20,16 @@ suite('defer', function(){
         });
       });
     });
+  });
+
+  test("Should call a deferred callback with the given context", function(done) {
+    var fastdom = new FastDom();
+    var cb = sinon.spy();
+    var ctx = { foo: 'bar' };
+
+    fastdom.defer(2, function() {
+      assert.equal(this.foo, 'bar');
+      done();
+    }, ctx);
   });
 });


### PR DESCRIPTION
Proposed fix for #12
- Accept context for deferred jobs
- Test case for calling defer job with context
- Halt defer wrapper when frame is negative

In the original code, if I call defer with a negative frame, like `fastdom.defer(-1, fn)`, the inner wrapper function will run infinitely. It's a bit difficult to write a proper test case for this scenario, but I'm sure you get the picture.
