### PR TITLE
use module pattern instead of singleton

### DIFF
--- a/lib/fastdom.js
+++ b/lib/fastdom.js
@@ -9,7 +9,7 @@
  * @author Wilson Page <wilsonpage@me.com>
  */
 
-;(function(fastdom){
+;(function(){
 
   'use strict';
 
@@ -30,29 +30,12 @@
     || window.msCancelRequestAnimationFrame
     || function(id) { window.clearTimeout(id); };
 
-  // Use existing instance if
-  // one already exists in
-  // this app, else make one.
-  fastdom = (fastdom instanceof FastDom)
-    ? fastdom
-    : new FastDom();
-
-  /**
-   * Creates a fresh
-   * FastDom instance.
-   *
-   * @constructor
-   */
-  function FastDom() {
-    this.lastId = 0;
-    this.jobs = {};
-    this.mode = null;
-    this.pending = false;
-    this.queue = {
-      read: [],
-      write: []
-    };
-  }
+  var lastId = 0,
+      jobs = {},
+      mode = null,
+      pending = false,
+      readQueue = [],
+      writeQueue = [];
 
   /**
    * Adds a job to
@@ -61,10 +44,10 @@
    * @param  {Function} fn
    * @api public
    */
-  FastDom.prototype.read = function(fn, ctx) {
-    var job = this._add('read', fn, ctx);
-    this.queue.read.push(job.id);
-    this._request('read');
+  var read = function(fn, ctx) {
+    var job = _add('read', fn, ctx);
+    readQueue.push(job.id);
+    _request('read');
     return job.id;
   };
 
@@ -75,10 +58,10 @@
    * @param  {Function} fn
    * @api public
    */
-  FastDom.prototype.write = function(fn, ctx) {
-    var job = this._add('write', fn, ctx);
-    this.queue.write.push(job.id);
-    this._request('write');
+  var write = function(fn, ctx) {
+    var job = _add('write', fn, ctx);
+    writeQueue.push(job.id);
+    _request('write');
     return job.id;
   };
 
@@ -89,8 +72,8 @@
    * @param  {Number} id
    * @api public
    */
-  FastDom.prototype.clear = function(id) {
-    var job = this.jobs[id];
+  var clear = function(id) {
+    var job = jobs[id];
     if (!job) return;
 
     // Defer jobs are cleared differently
@@ -99,11 +82,11 @@
       return;
     }
 
-    var list = this.queue[job.type];
+    var list = ( job.type === 'read' ? readQueue : writeQueue );
     var index = list.indexOf(id);
 
     if (~index) list.splice(index, 1);
-    delete this.jobs[id];
+    delete jobs[id];
   };
 
   /**
@@ -114,10 +97,7 @@
    * @param  {String} type
    * @api private
    */
-  FastDom.prototype._request = function(type) {
-    var mode = this.mode;
-    var self = this;
-
+  var _request = function(type) {
     // If we are currently writing, we don't
     // need to scedule a new frame as this
     // job will be emptied from the write queue
@@ -136,14 +116,14 @@
 
     // If there is already a frame
     // scheduled, don't schedule another one
-    if (this.pending) return;
+    if (pending) return;
 
     // Schedule frame (preserving context)
-    raf(function() { self._frame(); });
+    raf(_frame);
 
     // Set flag to indicate
     // a frame has been scheduled
-    this.pending = true;
+    pending = true;
   };
 
   /**
@@ -152,8 +132,8 @@
    *
    * @return {Number}
    */
-  FastDom.prototype._uniqueId = function() {
-    return ++this.lastId;
+  var _uniqueId = function() {
+    return ++lastId;
   };
 
   /**
@@ -168,17 +148,17 @@
    * @param  {Array} list
    * @api private
    */
-  FastDom.prototype._run = function(list) {
+  var _run = function(list) {
     var ctx;
     var job;
     var id;
 
     while (id = list.shift()) {
-      job = this.jobs[id];
-      ctx = job.ctx || this;
-      delete this.jobs[id];
+      job = jobs[id];
+      ctx = job.ctx || fastdom;
+      delete jobs[id];
       try { job.fn.call(ctx); } catch (e) {
-        if (this.onError) this.onError(e);
+        if (fastdom.onError) fastdom.onError(e);
       }
     }
   };
@@ -189,24 +169,24 @@
    *
    * @api private
    */
-  FastDom.prototype._frame = function() {
+  var _frame = function() {
 
     // Set the pending flag to
     // false so that any new requests
     // that come in will schedule a new frame
-    this.pending = false;
+    pending = false;
 
     // Set the mode to 'reading',
     // then empty all read jobs
-    this.mode = 'reading';
-    this._run(this.queue.read);
+    mode = 'reading';
+    _run(readQueue);
 
     // Set the mode to 'writing'
     // then empty all write jobs
-    this.mode = 'writing';
-    this._run(this.queue.write);
+    mode = 'writing';
+    _run(writeQueue);
 
-    this.mode = null;
+    mode = null;
   };
 
   /**
@@ -218,13 +198,13 @@
    * @param  {Function} fn
    * @api public
    */
-  FastDom.prototype.defer = function(frames, fn, ctx) {
+  var defer = function(frames, fn, ctx) {
     if (frames < 0) return;
-    var job = this._add('defer', fn);
+    var job = _add('defer', fn);
     (function wrapped() {
       if (frames-- === 0) {
         try { fn.call(ctx); } catch(e) {
-          if (this.onError) this.onError(e);
+          if (fastdom.onError) fastdom.onError(e);
         }
       } else {
         job.timer = raf(wrapped);
@@ -243,9 +223,9 @@
    * @returns {Number} id
    * @api private
    */
-  FastDom.prototype._add = function(type, fn, ctx) {
-    var id = this._uniqueId();
-    return this.jobs[id] = {
+  var _add = function(type, fn, ctx) {
+    var id = _uniqueId();
+    return jobs[id] = {
       id: id,
       fn: fn,
       ctx: ctx,
@@ -260,15 +240,24 @@
    * @param  {Number} id
    * @api private
    */
-  FastDom.prototype._remove = function(list, id) {
+  var _remove = function(list, id) {
     var index = list.indexOf(id);
     if (~index) list.splice(index, 1);
-    delete this.jobs[id];
+    delete jobs[id];
   };
 
   /**
    * Expose 'FastDom'
    */
+  var fastdom = {
+    read: read,
+    write: write,
+    clear: clear,
+    defer: defer,
+
+    // exposed properties (only necessary for testing?)
+    jobs: jobs
+  };
 
   if (typeof exports === "object") {
     module.exports = fastdom;
@@ -278,4 +267,4 @@
     window['fastdom'] = fastdom;
   }
 
-})(window.fastdom);
+})();

--- a/test/setup.js
+++ b/test/setup.js
@@ -5,9 +5,6 @@ var raf = window.requestAnimationFrame
   || window.mozRequestAnimationFrame
   || function(cb) { window.setTimeout(cb, 1000 / 60); };
 
-// Make constructor
-var FastDom = fastdom.constructor;
-
 // Alias chai.assert
 var assert = chai.assert;
 

--- a/test/test.clear.js
+++ b/test/test.clear.js
@@ -2,7 +2,6 @@
 suite('Clear', function(){
 
   test("Should not run 'read' job if cleared (sync)", function(done) {
-    var fastdom = new FastDom();
     var read = sinon.spy();
 
     var id = fastdom.read(read);
@@ -15,7 +14,6 @@ suite('Clear', function(){
   });
 
   test("Should fail silently if job not found in queue", function(done) {
-    var fastdom = new FastDom();
     var read = sinon.spy();
     var read2 = sinon.spy();
 
@@ -29,7 +27,6 @@ suite('Clear', function(){
   });
 
   test("Should not run 'write' job if cleared (async)", function(done) {
-    var fastdom = new FastDom();
     var read = sinon.spy();
     var write = sinon.spy();
 
@@ -45,7 +42,6 @@ suite('Clear', function(){
   });
 
   test("Should not run 'write' job if cleared", function(done) {
-    var fastdom = new FastDom();
     var write = sinon.spy();
     var id = fastdom.write(write);
 
@@ -58,7 +54,6 @@ suite('Clear', function(){
   });
 
   test("Should not run 'defer' job if cleared", function(done) {
-    var fastdom = new FastDom();
     var write = sinon.spy();
     var id = fastdom.defer(3, write);
 

--- a/test/test.defer.js
+++ b/test/test.defer.js
@@ -2,7 +2,6 @@
 suite('defer', function(){
 
   test("Should run the job after the specified number of frames", function(done) {
-    var fastdom = new FastDom();
     var job = sinon.spy();
 
     fastdom.defer(4, job);
@@ -23,7 +22,6 @@ suite('defer', function(){
   });
 
   test("Should call a deferred callback with the given context", function(done) {
-    var fastdom = new FastDom();
     var cb = sinon.spy();
     var ctx = { foo: 'bar' };
 

--- a/test/test.set.js
+++ b/test/test.set.js
@@ -2,8 +2,6 @@
 suite('Set', function() {
 
   test("Should run reads before writes", function(done) {
-    var fastdom = new FastDom();
-
     var read = sinon.spy(function() {
       assert(!write.called);
     });
@@ -18,7 +16,6 @@ suite('Set', function() {
   });
 
   test("Should call all reads together, followed by all writes", function(done) {
-    var fastdom = new FastDom();
     var read1 = sinon.spy();
     var read2 = sinon.spy();
     var write1 = sinon.spy();
@@ -42,7 +39,6 @@ suite('Set', function() {
   });
 
   test("Should call a read in the same frame if scheduled inside a read callback", function(done) {
-    var fastdom = new FastDom();
     var cb = sinon.spy();
 
     fastdom.read(function() {
@@ -63,7 +59,6 @@ suite('Set', function() {
   });
 
   test("Should call a write in the same frame if scheduled inside a read callback", function(done) {
-    var fastdom = new FastDom();
     var cb = sinon.spy();
 
     fastdom.read(function() {
@@ -84,7 +79,6 @@ suite('Set', function() {
   });
 
   test("Should call a read in the *next* frame if scheduled inside a write callback", function(done) {
-    var fastdom = new FastDom();
     var cb = sinon.spy();
 
     fastdom.write(function() {
@@ -104,7 +98,6 @@ suite('Set', function() {
   });
 
   test("Should call a 'read' callback with the given context", function(done) {
-    var fastdom = new FastDom();
     var cb = sinon.spy();
     var ctx = { foo: 'bar' };
 
@@ -115,7 +108,6 @@ suite('Set', function() {
   });
 
   test("Should call a 'write' callback with the given context", function(done) {
-    var fastdom = new FastDom();
     var cb = sinon.spy();
     var ctx = { foo: 'bar' };
 
@@ -126,8 +118,6 @@ suite('Set', function() {
   });
 
   test("Should have empty job hash when batch complete", function(done) {
-    var fastdom = new FastDom();
-
     fastdom.read(function(){});
     fastdom.read(function(){});
     fastdom.write(function(){});
@@ -143,7 +133,6 @@ suite('Set', function() {
   });
 
   test("Should maintain correct context if single method is registered twice", function(done) {
-    var fastdom = new FastDom();
     var ctx1 = { foo: 'bar' };
     var ctx2 = { bar: 'baz' };
 
@@ -163,7 +152,6 @@ suite('Set', function() {
   });
 
   test("Should call a registered onError handler when an error is thrown inside a job", function(done) {
-    var fastdom = new FastDom();
     var err1 = { some: 'error1' };
     var err2 = { some: 'error2' };
 


### PR DESCRIPTION
This is quite a ballsy pull request, feel free to disregard entirely if you see fit. Basically I wanted to satisfy my own curiosity, and thought I may as well share the result.

I was wondering what the rationale was for using a singleton rather than a module? As a module, all the internal guts (e.g. the unique ID, `_add` and so on) are hidden, and you don't have to create a new `raf(function() { self._frame(); })` for each request when `pending === false`, you can just do `raf(frame)`.

It's about 20% smaller minified (because there are no unmangleable `this` or property names), though gzipped the difference is negligible (a testament to gzip's efficiency).

Anyway as I say I won't be offended if you ignore this PR! Cracking work on the library, I think this will change the way a lot of people approach DOM manipulation.
