### PR TITLE
Use more standard test to expose Node.js module

### DIFF
--- a/index.js
+++ b/index.js
@@ -278,7 +278,7 @@
    * Expose 'fastdom'
    */
 
-  if (typeof exports === "object") {
+  if (typeof module !== 'undefined' && module.exports) {
     module.exports = fastdom;
   } else if (typeof define === "function" && define.amd) {
     define(function(){ return fastdom; });


### PR DESCRIPTION
`typeof exports === "object"` isn't a complete test for defining on module.exports, unless I'm crazy? Perhaps you wanted to do something unusual here?
