### PR TITLE
wrong _source notation: changed colon to slash notation

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -12,5 +12,5 @@
     "README.md"
   ],
   "license": "MIT",
-  "_source": "git@github.com:wilsonpage/fastdom.git"
+  "_source": "git@github.com/wilsonpage/fastdom.git"
 }


### PR DESCRIPTION
Sorry, copy fail. I want to fix following error after 'bower install fastdom':

bower fastdom#\* ECMDERR Failed to execute "git ls-remote --tags --heads git://github.com:wilsonpage/fastdom.git", exit code of #128
fatal: unable to connect to github.com:
github.com: Servname not supported for ai_socktype

Can you reproduce this error?
