### PR TITLE
fix the missing semicolons and add requestAnimationFrame only test to aspect ratio comparison example.

### DIFF
--- a/examples/aspect-ratio.html
+++ b/examples/aspect-ratio.html
@@ -20,6 +20,7 @@
 <body>
   <label>Number of elements <input id="input" type="text" value="100" /></label>
   <button id="withoutFastDom">Run without FastDom</button>
+  <button id="withRequestAnimationFrame">Run with requestAnimationFrame</button>
   <button id="withFastDom">Run with FastDom</button>
   <button id="resetbtn">reset</button>
   <section id="perf"></section>
@@ -56,6 +57,25 @@
       }
     }
 
+    function setAspectRequestAnimationFrame(div, i) {
+      var aspect = 9/16;
+      var isLast = i === (n - 1);
+
+      // READ
+      requestAnimationFrame(function() {
+        var h = div.clientWidth * aspect;
+
+        // WRITE
+        requestAnimationFrame(function() {
+          div.style.height = h + 'px';
+
+          if (isLast) {
+            displayPerf(performance.now() - start);
+          }
+        });
+      });
+    }
+
     function setAspectFastDom(div, i) {
       var aspect = 9/16;
       var isLast = i === (n - 1);
@@ -89,6 +109,12 @@
       reset();
       start = performance.now();
       divs.forEach(setAspectFastDom);
+    };
+
+    withRequestAnimationFrame.onclick = function() {
+      reset();
+      start = performance.now();
+      divs.forEach(setAspectRequestAnimationFrame);
     };
 
     resetbtn.onclick = reset;

--- a/examples/aspect-ratio.html
+++ b/examples/aspect-ratio.html
@@ -46,7 +46,7 @@
 
     function setAspect(div, i) {
       var aspect = 9/16;
-      var isLast = i === (n - 1)
+      var isLast = i === (n - 1);
       var h = div.clientWidth * aspect;
 
       div.style.height = h + 'px';
@@ -58,7 +58,7 @@
 
     function setAspectFastDom(div, i) {
       var aspect = 9/16;
-      var isLast = i === (n - 1)
+      var isLast = i === (n - 1);
 
       // READ
       fastdom.read(function() {


### PR DESCRIPTION
Adding requestAnimationFrame only test to aspect ratio comparison example gives more insight to users how batching could improve the performance even further.