### PR TITLE
Jank

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@
  * interactions.
  *
  * @author Wilson Page <wilsonpage@me.com>
+ * @author Kornel Lesinski <kornel.lesinski@ft.com>
  */
 
 ;(function(fastdom){
@@ -24,21 +25,18 @@
    * @constructor
    */
   function FastDom() {
-    this.frames = [];
-    this.lastId = 0;
-
     // Placing the rAF method
     // on the instance allows
     // us to replace it with
     // a stub for testing.
     this.raf = raf;
 
-    this.batch = {
-      hash: {},
-      read: [],
-      write: [],
-      mode: null
-    };
+    this.reads = [];
+    this.writes = [];
+    this.deferred = [];
+
+    this.onError = undefined;
+    this.flush = this.flush.bind(this);
   }
 
   /**
@@ -50,25 +48,10 @@
    * @public
    */
   FastDom.prototype.read = function(fn, ctx) {
-    var job = this.add('read', fn, ctx);
-    var id = job.id;
-
-    // Add this job to the read queue
-    this.batch.read.push(job.id);
-
-    // We should *not* schedule a new frame if:
-    // 1. We're 'reading'
-    // 2. A frame is already scheduled
-    var doesntNeedFrame = this.batch.mode === 'reading'
-      || this.batch.scheduled;
-
-    // If a frame isn't needed, return
-    if (doesntNeedFrame) return id;
-
-    // Schedule a new
-    // frame, then return
+    var job = {fn: fn, ctx: ctx};
+    this.reads.push(job);
     this.scheduleBatch();
-    return id;
+    return job;
   };
 
   /**
@@ -80,28 +63,10 @@
    * @public
    */
   FastDom.prototype.write = function(fn, ctx) {
-    var job = this.add('write', fn, ctx);
-    var mode = this.batch.mode;
-    var id = job.id;
-
-    // Push the job id into the queue
-    this.batch.write.push(job.id);
-
-    // We should *not* schedule a new frame if:
-    // 1. We are 'writing'
-    // 2. We are 'reading'
-    // 3. A frame is already scheduled.
-    var doesntNeedFrame = mode === 'writing'
-      || mode === 'reading'
-      || this.batch.scheduled;
-
-    // If a frame isn't needed, return
-    if (doesntNeedFrame) return id;
-
-    // Schedule a new
-    // frame, then return
+    var job = {fn: fn, ctx: ctx};
+    this.writes.push(job);
     this.scheduleBatch();
-    return id;
+    return job;
   };
 
   /**
@@ -126,40 +91,50 @@
       frame = 1;
     }
 
-    var self = this;
-    var index = frame - 1;
+    var job;
+    if (frame > 1) {
+      var lastFn = fn;
+      var that = this;
+      fn = function() {
+        if (--job.frame > 0) {
+          that.deferred.push(job);
+          that.scheduleBatch();
+        } else {
+          lastFn.call(job.ctx);
+        }
+      };
+    }
 
-    return this.schedule(index, function() {
-      self.run({
-        fn: fn,
-        ctx: ctx
-      });
-    });
+    job = {fn: fn, ctx: ctx, frame: frame};
+    this.deferred.push(job);
+    this.scheduleBatch();
+    return job;
   };
 
   /**
    * Clears a scheduled 'read',
    * 'write' or 'defer' job.
    *
-   * @param  {Number} id
+   * @param {Object} id
    * @public
    */
-  FastDom.prototype.clear = function(id) {
-
-    // Defer jobs are cleared differently
-    if (typeof id === 'function') {
-      return this.clearFrame(id);
+  FastDom.prototype.clear = function(job) {
+    var idx;
+    idx = this.reads.indexOf(job);
+    if (idx >= 0) {
+      this.reads.splice(idx, 1);
+      return;
     }
-
-    var job = this.batch.hash[id];
-    if (!job) return;
-
-    var list = this.batch[job.type];
-    var index = list.indexOf(id);
-
-    // Clear references
-    delete this.batch.hash[id];
-    if (~index) list.splice(index, 1);
+    idx = this.writes.indexOf(job);
+    if (idx >= 0) {
+      this.writes.splice(idx, 1);
+      return;
+    }
+    idx = this.deferred.indexOf(job);
+    if (idx >= 0) {
+      this.deferred.splice(idx, 1);
+      return;
+    }
   };
 
   /**
@@ -169,42 +144,40 @@
    * @private
    */
   FastDom.prototype.scheduleBatch = function() {
-    var self = this;
-
-    // Schedule batch for next frame
-    this.schedule(0, function() {
-      self.batch.scheduled = false;
-      self.runBatch();
-    });
-
-    // Set flag to indicate
-    // a frame has been scheduled
-    this.batch.scheduled = true;
+    if (this.scheduled) return;
+    this.scheduled = true;
+    raf(this.flush);
   };
 
-  /**
-   * Calls each job in
-   * the list passed.
-   *
-   * If a context has been
-   * stored on the function
-   * then it is used, else the
-   * current `this` is used.
-   *
-   * @param  {Array} list
-   * @private
-   */
-  FastDom.prototype.flush = function(list) {
-    var id;
+  FastDom.prototype.flush = function() {
+    this.scheduled = false;
+    var error;
 
-    while (id = list.shift()) {
-      this.run(this.batch.hash[id]);
+    try {
+      if (this.runBatch(this.reads)) {
+        if (this.runBatch(this.writes)) {
+          this.runBatch(this.deferred);
+        }
+      }
+    } catch (e) {
+      error = e;
+    }
+
+    if (this.reads.length || this.writes.length || this.deferred.length) {
+      this.scheduleBatch();
+    }
+
+    if (error) {
+      if (this.onError) {
+        this.onError(error);
+      } else {
+        throw error;
+      }
     }
   };
 
   /**
-   * Runs any 'read' jobs followed
-   * by any 'write' jobs.
+   * Runs given jobs until framelimit (in ms) is reached
    *
    * We run this inside a try catch
    * so that if any jobs error, we
@@ -213,112 +186,12 @@
    *
    * @private
    */
-  FastDom.prototype.runBatch = function() {
-    try {
-
-      // Set the mode to 'reading',
-      // then empty all read jobs
-      this.batch.mode = 'reading';
-      this.flush(this.batch.read);
-
-      // Set the mode to 'writing'
-      // then empty all write jobs
-      this.batch.mode = 'writing';
-      this.flush(this.batch.write);
-
-      this.batch.mode = null;
-
-    } catch (e) {
-      this.runBatch();
-      throw e;
+  FastDom.prototype.runBatch = function(list) {
+    var job;
+    while (job = list.shift()) {
+      job.fn.call(job.ctx);
     }
-  };
-
-
-  /**
-   * Runs a given job.
-   *
-   * Applications using FastDom
-   * have the options of setting
-   * `fastdom.onError`.
-   *
-   * This will catch any
-   * errors that may throw
-   * inside callbacks, which
-   * is useful as often DOM
-   * nodes have been removed
-   * since a job was scheduled.
-   *
-   * Example:
-   *
-   *   fastdom.onError = function(e) {
-   *     // Runs when jobs error
-   *   };
-   *
-   * @param  {Object} job
-   * @private
-   */
-  FastDom.prototype.run = function(job){
-    var ctx = job.ctx || this;
-    var fn = job.fn;
-
-    // Clear reference to the job
-    delete this.batch.hash[job.id];
-
-    // If no `onError` handler
-    // has been registered, just
-    // run the job normally.
-    if (!this.onError) {
-      return fn.call(ctx);
-    }
-
-    // If an `onError` handler
-    // has been registered, catch
-    // errors that throw inside
-    // callbacks, and run the
-    // handler instead.
-    try { fn.call(ctx); } catch (e) {
-      this.onError(e);
-    }
-  };
-
-  /**
-   * Starts a rAF loop
-   * to empty the frame queue.
-   *
-   * @private
-   */
-  FastDom.prototype.loop = function() {
-    var self = this;
-    var raf = this.raf;
-
-    // Don't start more than one loop
-    if (this.looping) return;
-
-    raf(function frame() {
-      var fn = self.frames.shift();
-
-      // If no more frames,
-      // stop looping
-      if (!self.frames.length) {
-        self.looping = false;
-
-      // Otherwise, schedule the
-      // next frame
-      } else {
-        raf(frame);
-      }
-
-      // Run the frame.  Note that
-      // this may throw an error
-      // in user code, but all
-      // fastdom tasks are dealt
-      // with already so the code
-      // will continue to iterate
-      if (fn) fn();
-    });
-
-    this.looping = true;
+    return true;
   };
 
   // We only ever want there to be

--- a/index.js
+++ b/index.js
@@ -13,11 +13,9 @@
   'use strict';
 
   // Normalize rAF
-  var raf = window.requestAnimationFrame
-    || window.webkitRequestAnimationFrame
-    || window.mozRequestAnimationFrame
-    || window.msRequestAnimationFrame
-    || function(cb) { return window.setTimeout(cb, 1000 / 60); };
+  var raf = window.requestAnimationFrame || window.webkitRequestAnimationFrame || window.mozRequestAnimationFrame || window.msRequestAnimationFrame || function(cb) {
+    return window.setTimeout(cb, 16);
+  };
 
   /**
    * Creates a fresh

--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@
 
   // Normalize rAF
   var raf = window.requestAnimationFrame || window.webkitRequestAnimationFrame || window.mozRequestAnimationFrame || window.msRequestAnimationFrame || function(cb) {
-    return window.setTimeout(cb, 16);
+    return setTimeout(cb, 16);
   };
 
   /**

--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@
     // on the instance allows
     // us to replace it with
     // a stub for testing.
-    this.raf = raf;
+    this.raf = raf.bind(window);
 
     this.reads = [];
     this.writes = [];
@@ -146,7 +146,7 @@
   FastDom.prototype.scheduleBatch = function() {
     if (this.scheduled) return;
     this.scheduled = true;
-    raf(this.flush);
+    this.raf(this.flush);
   };
 
   FastDom.prototype.flush = function() {

--- a/index.js
+++ b/index.js
@@ -163,17 +163,6 @@
   };
 
   /**
-   * Clears a scheduled frame.
-   *
-   * @param  {Function} frame
-   * @private
-   */
-  FastDom.prototype.clearFrame = function(frame) {
-    var index = this.frames.indexOf(frame);
-    if (~index) this.frames.splice(index, 1);
-  };
-
-  /**
    * Schedules a new read/write
    * batch if one isn't pending.
    *
@@ -191,17 +180,6 @@
     // Set flag to indicate
     // a frame has been scheduled
     this.batch.scheduled = true;
-  };
-
-  /**
-   * Generates a unique
-   * id for a job.
-   *
-   * @return {Number}
-   * @private
-   */
-  FastDom.prototype.uniqueId = function() {
-    return ++this.lastId;
   };
 
   /**
@@ -256,25 +234,6 @@
     }
   };
 
-  /**
-   * Adds a new job to
-   * the given batch.
-   *
-   * @param {Array}   list
-   * @param {Function} fn
-   * @param {Object}   ctx
-   * @returns {Number} id
-   * @private
-   */
-  FastDom.prototype.add = function(type, fn, ctx) {
-    var id = this.uniqueId();
-    return this.batch.hash[id] = {
-      id: id,
-      fn: fn,
-      ctx: ctx,
-      type: type
-    };
-  };
 
   /**
    * Runs a given job.
@@ -360,36 +319,6 @@
     });
 
     this.looping = true;
-  };
-
-  /**
-   * Adds a function to
-   * a specified index
-   * of the frame queue.
-   *
-   * @param  {Number}   index
-   * @param  {Function} fn
-   * @return {Function}
-   * @private
-   */
-  FastDom.prototype.schedule = function(index, fn) {
-
-    // Make sure this slot
-    // hasn't already been
-    // taken. If it has, try
-    // re-scheduling for the next slot
-    if (this.frames[index]) {
-      return this.schedule(index + 1, fn);
-    }
-
-    // Start the rAF
-    // loop to empty
-    // the frame queue
-    this.loop();
-
-    // Insert this function into
-    // the frames queue and return
-    return this.frames[index] = fn;
   };
 
   // We only ever want there to be

--- a/index.js
+++ b/index.js
@@ -158,9 +158,9 @@
     var deferredTimeLimit = 12;
 
     try {
-      if (this.runBatch(this.reads, start, readBatchTimeLimit)) {
-        if (this.runBatch(this.writes, start, writeBatchTimeLimit)) {
-          this.runBatch(this.deferred, start, deferredTimeLimit);
+      if (this.runBatch(this.reads, 10000, start, readBatchTimeLimit)) {
+        if (this.runBatch(this.writes, 10000, start, writeBatchTimeLimit)) {
+          this.runBatch(this.deferred, this.deferred.length, start, deferredTimeLimit); // deferred.length ensures newly deferred jobs aren't run immediately
         }
       }
     } catch (e) {
@@ -191,9 +191,9 @@
    *
    * @private
    */
-  FastDom.prototype.runBatch = function(list, start, frameTimeLimit) {
+  FastDom.prototype.runBatch = function(list, maxJobs, start, frameTimeLimit) {
     var job;
-    while (job = list.shift()) {
+    while (maxJobs-- && (job = list.shift())) {
       job.fn.call(job.ctx);
       var took = Date.now() - start;
       if (took > frameTimeLimit) {

--- a/index.js
+++ b/index.js
@@ -150,7 +150,6 @@
   };
 
   FastDom.prototype.flush = function() {
-    this.scheduled = false;
     var start = Date.now();
     var error;
 
@@ -168,6 +167,7 @@
       error = e;
     }
 
+    this.scheduled = false;
     if (this.reads.length || this.writes.length || this.deferred.length) {
       this.scheduleBatch();
     }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
     "jshint": "~2.1.0",
     "sinon": "~1.7.3",
     "chai": "~1.7.2",
-    "mocha-phantomjs": "~3.1.2"
+    "mocha-phantomjs": "~3.1.2",
+    "phantomjs": "*",
+    "polyfill-function-prototype-bind": "0.0.1"
   }
 }

--- a/test/index.html
+++ b/test/index.html
@@ -13,6 +13,7 @@
   <script src="../node_modules/sinon/lib/sinon/match.js"></script>
   <script src="../node_modules/sinon/lib/sinon/spy.js"></script>
   <script src="../node_modules/sinon/lib/sinon/stub.js"></script>
+  <script src="../node_modules/polyfill-function-prototype-bind/bind.js"></script>
   <script>mocha.setup('tdd')</script>
   <script src="../index.js"></script>
   <script src="setup.js"></script>

--- a/test/test.clear.js
+++ b/test/test.clear.js
@@ -87,7 +87,6 @@ suite('clear', function(){
       raf(function() {
         raf(function() {
           assert(!write.called);
-          assert(!fastdom.batch.hash[id]);
           done();
         });
       });

--- a/test/test.defer.js
+++ b/test/test.defer.js
@@ -43,31 +43,6 @@ suite('defer', function(){
     });
   });
 
-  test('Should run each job on a different frame.', function(done) {
-    var fastdom = new FastDom();
-    var callback1 = sinon.spy();
-    var callback2 = sinon.spy();
-    var callback3 = sinon.spy();
-
-    fastdom.defer(callback1);
-    fastdom.defer(callback2);
-    fastdom.defer(callback3);
-
-    raf(function() {
-      assert(callback1.called);
-      assert(!callback2.called);
-      assert(!callback3.called);
-      raf(function() {
-        assert(callback2.called);
-        assert(!callback3.called);
-        raf(function() {
-          assert(callback3.called);
-          done();
-        });
-      });
-    });
-  });
-
   test('Should run fill empty frames before later work is run.', function(done) {
     var fastdom = new FastDom();
     var callback1 = sinon.spy();
@@ -79,13 +54,13 @@ suite('defer', function(){
     fastdom.defer(3, callback3);
 
     // Frame 1
-    fastdom.defer(callback1);
+    fastdom.defer(1, callback1);
 
     // Frame 2
-    fastdom.defer(callback2);
+    fastdom.defer(2, callback2);
 
     // Frame 4
-    fastdom.defer(callback4);
+    fastdom.defer(4, callback4);
 
     raf(function() {
       assert(callback1.called);

--- a/test/test.set.js
+++ b/test/test.set.js
@@ -259,10 +259,12 @@ suite('set', function() {
     });
 
     raf(function() {
-      assert(fastdom.onError.calledTwice);
-      assert(fastdom.onError.getCall(0).calledWith(err1));
-      assert(fastdom.onError.getCall(1).calledWith(err2));
-      done();
+      raf(function() {
+        assert(fastdom.onError.calledTwice,'twice');
+        assert(fastdom.onError.getCall(0).calledWith(err1),'bla');
+        assert(fastdom.onError.getCall(1).calledWith(err2),'bl2');
+        done();
+      });
     });
   });
 
@@ -276,41 +278,6 @@ suite('set', function() {
 
     raf(function() {
       assert(callback.called);
-      assert(fastdom.flush.calledOnce);
-      done();
-    });
-  });
-
-
-  test('Should continue to flush the queue until empty even if a job errors', function(done) {
-    var fastdom = new FastDom();
-    var read = sinon.spy();
-    var write = sinon.spy();
-    var flush = fastdom.runBatch;
-    var error = sinon.stub().throws();
-    var errorsThrown = false;
-
-    sinon.stub(fastdom, 'runBatch', function() {
-      try {
-        flush.apply(fastdom, arguments);
-      } catch (e) {
-        errorsThrown = true;
-      }
-    });
-
-    fastdom.read(read);
-    fastdom.write(write);
-    fastdom.read(error);
-    fastdom.read(read);
-    fastdom.write(error);
-    fastdom.write(write);
-
-    raf(function() {
-      assert(read.calledTwice, 'the callback was called both times');
-      assert(write.calledTwice, 'the callback was called both times');
-      assert(fastdom.batch.read.length === 0, 'the queue is empty');
-      assert(fastdom.batch.write.length === 0, 'the queue is empty');
-      assert(errorsThrown, 'real errors were thrown');
       assert(fastdom.flush.calledOnce);
       done();
     });


### PR DESCRIPTION
Major changes:

* Looping done using a regular `for` loop instead of recursion. 
* Exceptions always interrupt batches, so exceptions aren't lost when multiple jobs throw exceptions (and behaviour with/without `onError` is more consistent)
* There's no explicit scheduling of multiple future frames. I'm not convinced that it's useful enough to warrant extra complexity it adds. I've hacked a sort-of-similar delay in `defer` for backwards compatibility only.
* And a big one: **batches are timed and run for no longer than 16ms** (where possible). This is intended to reduce jank. If the app schedules a lot of work, then the work gets spread over multiple frames to avoid jank and blocking of the main thread.