### PR TITLE
Bind to whichever global context is available

### DIFF
--- a/fastdom.js
+++ b/fastdom.js
@@ -239,4 +239,4 @@ var exports = win.fastdom = (win.fastdom || new FastDom()); // jshint ignore:lin
 if ((typeof define)[0] == 'f') define(function() { return exports; });
 else if ((typeof module)[0] == 'o') module.exports = exports;
 
-})(window);
+})(this);


### PR DESCRIPTION
This lets fastdom be used in environments where no `window` global is available. My own use-case is integration testing modules that rely on fastdom in node using jsdom.