### PR TITLE
extract context binding from loop, apply when added

### DIFF
--- a/fastdom.js
+++ b/fastdom.js
@@ -56,7 +56,7 @@ FastDom.prototype = {
    */
   measure: function(fn, ctx) {
     debug('measure');
-    var task = { fn: fn, ctx: ctx };
+    var task = !ctx ? fn : fn.bind(ctx);
     this.reads.push(task);
     scheduleFlush(this);
     return task;
@@ -72,7 +72,7 @@ FastDom.prototype = {
    */
   mutate: function(fn, ctx) {
     debug('mutate');
-    var task = { fn: fn, ctx: ctx };
+    var task = !ctx ? fn : fn.bind(ctx);
     this.writes.push(task);
     scheduleFlush(this);
     return task;
@@ -203,7 +203,7 @@ function flush(fastdom) {
  */
 function runTasks(tasks) {
   debug('run tasks');
-  var task; while (task = tasks.shift()) task.fn.call(task.ctx);
+  var task; while (task = tasks.shift()) task();
 }
 
 /**

--- a/test/fastdom-test.js
+++ b/test/fastdom-test.js
@@ -340,7 +340,7 @@ suite('fastdom', function() {
 
     test('it removes reference to the job if cleared', function(done) {
       var write = sinon.spy();
-      var id = fastdom.mutate(2, write);
+      var id = fastdom.mutate(function () { return false; }, write);
 
       fastdom.clear(id);
 

--- a/test/fastdom-test.js
+++ b/test/fastdom-test.js
@@ -340,7 +340,7 @@ suite('fastdom', function() {
 
     test('it removes reference to the job if cleared', function(done) {
       var write = sinon.spy();
-      var id = fastdom.mutate(function () { return false; }, write);
+      var id = fastdom.mutate(write);
 
       fastdom.clear(id);
 


### PR DESCRIPTION
Normally micro-optimizations like this aren't beneficial but the use-case for this library is an exception.