### PR TITLE
Use "more standard" AMD/CJS detect syntax

### DIFF
--- a/fastdom.js
+++ b/fastdom.js
@@ -236,7 +236,7 @@ function mixin(target, source) {
 var exports = win.fastdom = (win.fastdom || new FastDom()); // jshint ignore:line
 
 // Expose to CJS & AMD
-if ((typeof define)[0] == 'f') define(function() { return exports; });
-else if ((typeof module)[0] == 'o') module.exports = exports;
+if ((typeof define) == 'function') define(function() { return exports; });
+else if ((typeof module) == 'object') module.exports = exports;
 
 })( typeof window !== 'undefined' ? window : this);


### PR DESCRIPTION
This will allow tools like AMDClean https://github.com/gfranko/amdclean to recognise the expression.