### PR TITLE
Standard typescript export

### DIFF
--- a/fastdom.d.ts
+++ b/fastdom.d.ts
@@ -10,4 +10,4 @@ declare class Fastdom {
 
 declare const fastdom: Fastdom
 
-export = fastdom;
+export default fastdom;


### PR DESCRIPTION
Prevents typescript from using interop, that can cause problems: https://github.com/rollup/plugins/issues/943