### PR TITLE
fix: globalThis

### DIFF
--- a/fastdom.js
+++ b/fastdom.js
@@ -241,4 +241,4 @@ var exports = win.fastdom = (win.fastdom || new FastDom()); // jshint ignore:lin
 if ((typeof define) == 'function') define(function() { return exports; });
 else if ((typeof module) == 'object') module.exports = exports;
 
-})( typeof window !== 'undefined' ? window : this);
+})( typeof window !== 'undefined' ? window : typeof this != 'undefined' ? this : globalThis);


### PR DESCRIPTION
This PR aims to fix a problem I encountered where top level `this` in global scope was `undefined`. Most likely because my environment was running in "strict mode". A better description of the problem is in issue #131 .

I only added `globalThis` and did not replace `this` since I don't know what browser support this project has, and `globalThis` is not supported in IE 🙈.

All tests passed.

Sincerely, Hedinn